### PR TITLE
feat: add data validation script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "nodemon src/server.js",
-    "etl": "node src/pipeline/etl.js"
+    "etl": "node src/pipeline/etl.js",
+    "check-data": "node src/check_data.js"
   },
   "dependencies": {
     "axios": "^1.6.8",

--- a/backend/src/check_data.js
+++ b/backend/src/check_data.js
@@ -1,0 +1,36 @@
+require('dotenv').config();
+const sequelize = require('./db');
+
+async function checkData() {
+  try {
+    await sequelize.authenticate();
+    console.log('DB connection OK');
+
+    const [countResults] = await sequelize.query(
+      'SELECT COUNT(*) AS count FROM parcels_merged;'
+    );
+    const count = parseInt(countResults[0].count, 10);
+    console.log(`parcels_merged has ${count} rows.`);
+
+    if (count > 0) {
+      const [rows] = await sequelize.query(
+        'SELECT * FROM parcels_merged LIMIT 5;'
+      );
+      console.log('Sample rows from parcels_merged:');
+      console.table(rows);
+      console.log('Data looks OK');
+    } else {
+      console.warn('Data table is empty');
+    }
+  } catch (err) {
+    console.error('Data check failed:', err);
+  } finally {
+    await sequelize.close();
+  }
+}
+
+if (require.main === module) {
+  checkData();
+}
+
+module.exports = checkData;


### PR DESCRIPTION
## Summary
- add script to query parcels_merged table and report row count
- display first few parcel records when data exists
- expose `check-data` npm script for database verification

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check-data` (fails: ConnectionRefusedError)


------
https://chatgpt.com/codex/tasks/task_e_688dfbb96dbc833084c1205694964d0d